### PR TITLE
Updating c4 data loader as allenai--c4 config doesn't exist

### DIFF
--- a/datautils.py
+++ b/datautils.py
@@ -63,10 +63,10 @@ def get_ptb(nsamples, seed, seqlen, model, tokenizer):
 
 def get_c4(nsamples, seed, seqlen, model, tokenizer):
     traindata = load_dataset(
-        'allenai/c4', 'allenai--c4', data_files={'train': 'en/c4-train.00000-of-01024.json.gz'}, split='train'
+        'allenai/c4', data_files={'train': 'en/c4-train.00000-of-01024.json.gz'}, split='train'
     )
     valdata = load_dataset(
-        'allenai/c4', 'allenai--c4', data_files={'validation': 'en/c4-validation.00000-of-00008.json.gz'}, split='validation'
+        'allenai/c4', data_files={'validation': 'en/c4-validation.00000-of-00008.json.gz'}, split='validation'
     )
 
     random.seed(seed)


### PR DESCRIPTION
Issue faced : ValueError: BuilderConfig 'allenai--c4' not found
Reason : allenai--c4 config is depreciated now. 
Fix: Removing the parameter in load_dataset function call.

Checks:
Verified by running the opt.py on c4 data, which calls the get_c4()  function.