### PR TITLE
Add trust_remote_code=True to support loading local custom models

### DIFF
--- a/bloom.py
+++ b/bloom.py
@@ -23,7 +23,7 @@ def get_bloom(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import BloomForCausalLM
-    model = BloomForCausalLM.from_pretrained(model, torch_dtype='auto')
+    model = BloomForCausalLM.from_pretrained(model, torch_dtype='auto', trust_remote_code=True)
     model.seqlen = 2048
     return model
 

--- a/datautils.py
+++ b/datautils.py
@@ -12,7 +12,7 @@ def set_seed(seed):
 
 def get_tokenizer(model):
     if "llama" in model.lower():
-        tokenizer = LlamaTokenizer.from_pretrained(model, use_fast=False)
+        tokenizer = LlamaTokenizer.from_pretrained(model, use_fast=False, trust_remote_code=True)
         # fix for transformer 4.28.0.dev0 compatibility
         if tokenizer.bos_token_id != 1 or tokenizer.eos_token_id != 2:
             try:
@@ -21,7 +21,7 @@ def get_tokenizer(model):
             except AttributeError:
                 pass
     else:
-        tokenizer = AutoTokenizer.from_pretrained(model, use_fast=False)
+        tokenizer = AutoTokenizer.from_pretrained(model, use_fast=False, trust_remote_code=True)
     return tokenizer
 
 def get_wikitext2(nsamples, seed, seqlen, model, tokenizer):

--- a/llama.py
+++ b/llama.py
@@ -22,7 +22,7 @@ def get_llama(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import LlamaForCausalLM
-    model = LlamaForCausalLM.from_pretrained(model, torch_dtype='auto')
+    model = LlamaForCausalLM.from_pretrained(model, torch_dtype='auto', trust_remote_code=True)
     model.seqlen = 2048
     return model
 

--- a/opt.py
+++ b/opt.py
@@ -22,7 +22,7 @@ def get_opt(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import OPTForCausalLM
-    model = OPTForCausalLM.from_pretrained(model, torch_dtype='auto')
+    model = OPTForCausalLM.from_pretrained(model, torch_dtype='auto', trust_remote_code=True)
     model.seqlen = model.config.max_position_embeddings
     return model
 


### PR DESCRIPTION
Avoid repeatly verification when initializing local custom models and tokenizers.

To suppress warning like:
```bash
....
You can avoid this prompt in future by passing the argument `trust_remote_code=True`.
Do you wish to run the custom code? [y/N] 
....
```